### PR TITLE
[#4] Fix copy/paste keyboard shortcuts on macOS

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -108,6 +108,36 @@ export function createApplicationMenu(mainWindow: BrowserWindow): void {
       ],
     }] : []),
 
+    // Edit menu (required for copy/paste to work on macOS)
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        ...(isMac ? [
+          { role: 'pasteAndMatchStyle' as const },
+          { role: 'delete' as const },
+          { role: 'selectAll' as const },
+          { type: 'separator' as const },
+          {
+            label: 'Speech',
+            submenu: [
+              { role: 'startSpeaking' as const },
+              { role: 'stopSpeaking' as const },
+            ],
+          },
+        ] : [
+          { role: 'delete' as const },
+          { type: 'separator' as const },
+          { role: 'selectAll' as const },
+        ]),
+      ],
+    },
+
     // Session menu
     {
       label: 'Session',


### PR DESCRIPTION
## Summary

- Adds Edit menu to application menu to enable standard clipboard shortcuts on macOS

## Jira Issue

[#4](https://github.com/William-Long-II/claudelander/issues/4) - Copy/paste keyboard shortcuts don't work on macOS

## Type of Change

- [x] Bug fix (fixes an issue)

## Changes Made

- Added Edit menu to `src/main/menu.ts` with standard clipboard roles:
  - Undo/Redo
  - Cut/Copy/Paste
  - Paste and Match Style (macOS only)
  - Delete/Select All
  - Speech submenu (macOS only)

## Root Cause

On macOS, Electron apps require an explicit Edit menu with role-based menu items for clipboard shortcuts (Cmd+C, Cmd+V, Cmd+X, Cmd+A) to work in text fields. The OS routes these operations through the application menu, so without an Edit menu, the shortcuts don't function.

## Testing

- [x] Build passes (`npm run build:main`)
- [ ] Manual testing on macOS - copy/paste works in text fields

## Screenshots

N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Branch is up to date with main

## Breaking Changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)