### PR TITLE
fix: scroll terminal to bottom on session switch

### DIFF
--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -44,6 +44,17 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
     return () => window.removeEventListener('focus-terminal', handleFocusTerminal);
   }, [isActive]);
 
+  // Scroll to bottom when terminal becomes active (session switch)
+  useEffect(() => {
+    if (isActive && xtermRef.current && fitAddonRef.current) {
+      // Fit first to ensure dimensions are correct, then scroll to bottom
+      requestAnimationFrame(() => {
+        fitAddonRef.current?.fit();
+        xtermRef.current?.scrollToBottom();
+      });
+    }
+  }, [isActive]);
+
   // Copy text from terminal selection
   const handleCopy = useCallback(() => {
     const term = xtermRef.current;


### PR DESCRIPTION
## Summary
- Fixes intermittent terminal scroll issue when switching sessions
- Terminal now explicitly scrolls to bottom when becoming active
- Previously relied on ResizeObserver which only fired when dimensions changed

## Root Cause
When switching sessions via `display: flex/none`, the terminal became visible but:
- ResizeObserver only fired if container dimensions changed
- No explicit scroll-to-bottom was triggered
- Result: intermittent scroll failures

## Solution
Added useEffect in `Terminal.tsx` that watches `isActive` prop and calls:
1. `fitAddon.fit()` - ensure dimensions are correct
2. `scrollToBottom()` - explicitly scroll terminal

## Test plan
- [x] Create 2+ sessions with terminal output
- [x] Switch between sessions multiple times
- [x] Verify terminal always scrolls to bottom

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)